### PR TITLE
Add support for local files/other URLs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 youtube-transcript-api
 openai
+validators

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-youtube-transcript-api
+requests
 openai
 validators
+youtube-transcript-api

--- a/summawise/__main__.py
+++ b/summawise/__main__.py
@@ -1,62 +1,40 @@
-import ai, youtube, utils
+import ai, youtube, utils, validators
 from settings import init_settings
 
+class NotSupportedError(Exception):
+    def __init__(self):
+        super().__init__("Failed to vectorize data. Your input type is not yet supported.")
+
+def process_input(input_str: str) -> str:
+    """Takes user input, attempts to return OpenAI VectorStore ID after processing data."""
+    if validators.url(input_str):
+        # it's a URL
+        url = input_str
+
+        # youtube url handling
+        if youtube.is_url(url):
+            return youtube.process(url)
+
+    raise NotSupportedError()
+
+
 def main():
-    youtube_url = input("Enter a YouTube video URL: ")
     settings = init_settings()
 
     if not hasattr(ai, "client"):
         # TODO(justin): handle api key that becomes invalid *after* initial setup prompts
         ai.init(settings.api_key)
-    
-    # file extension to cache certain ojects/data (json or bin)
-    ext = settings.data_mode.ext()
 
-    # get youtube video id
+    input_str = input("Enter a URL or local file path: ")
+
     try:
-        video_id = youtube.parse_video_id(youtube_url)
-        print(f"Extracted Video ID: {video_id}")
-    except ValueError as e:
-        print(e)
+        vector_store_id = process_input(input_str)
+    except NotSupportedError as ex:
+        print(ex)
         return
-    
-    name = f"transcript_{video_id}"
-    transcript_path = utils.get_summawise_dir() / "youtube" / f"{name}.{ext}"
-    exists = transcript_path.exists()
-
-    if not exists and transcript_path.suffix != ".bin":
-        # check for gzipped variation of generated file path
-        gz_path = transcript_path.with_suffix(transcript_path.suffix + ".gz")
-        if gz_path.exists():
-            transcript_path = gz_path
-            exists = True
-
-    if not exists:
-        # fetch transcript data from youtube
-        try:
-            transcript = youtube.get_transcript(video_id)
-            print("Transcript retrieved and converted to text.")
-        except Exception as e:
-            print(f"Error retrieving transcript ({type(e).__name__}): {e}")
-            return
-        
-        # create vector store on openai, cache data
-        try:
-            vector_store_id = transcript.vectorize().id
-            transcript.save_to_file(
-                file_path = transcript_path,
-                mode = settings.data_mode,
-                compress = settings.compression
-            )
-            print(f"Vector store created with ID: {vector_store_id}")
-        except Exception as e:
-            print(f"Error creating vector store: {e}")
-            return
-    else:
-        # restore transcript object from file and use cached vector store id
-        transcript = youtube.load_transcript(transcript_path, settings.data_mode)
-        vector_store_id = transcript.vector_store_id
-        print(f"Restored vector store ID from cache: {transcript.vector_store_id}")
+    except Exception as ex:
+        print(f"An unhandled error occurred while processing input:\n{ex}")
+        return
 
     try:
         thread = ai.create_thread([vector_store_id], "Please summarize the transcript.")

--- a/summawise/__main__.py
+++ b/summawise/__main__.py
@@ -1,5 +1,6 @@
 import ai, youtube, utils, validators
 from settings import init_settings
+from utils import DataUnit
 
 class NotSupportedError(Exception):
     def __init__(self):
@@ -8,6 +9,7 @@ class NotSupportedError(Exception):
 def process_input(input_str: str) -> str:
     """Takes user input, attempts to return OpenAI VectorStore ID after processing data."""
     if validators.url(input_str):
+
         # it's a URL
         url = input_str
 
@@ -58,7 +60,7 @@ def main():
         vector_store = ai.client.beta.vector_stores.retrieve(vector_store_id) # model dump example: https://pastebin.com/k4fwANdi
         name = vector_store.name
         files = vector_store.file_counts.total
-        sz = utils.bytes_to_str(vector_store.usage_bytes)
+        sz = DataUnit.bytes_to_str(vector_store.usage_bytes)
         print(f"Successfully established vector store! [{name}, {files} file(s), {sz}]")
     except Exception as ex:
         print(f"Failed to validate VectorStore from provided ID (error: {type(ex)}, id: {vector_store_id}):\n{ex}")

--- a/summawise/__main__.py
+++ b/summawise/__main__.py
@@ -1,24 +1,90 @@
-import ai, youtube, utils, validators
+import ai, youtube, validators, requests, tempfile, os
 from settings import init_settings
 from utils import DataUnit
+from pathlib import Path
 
 class NotSupportedError(Exception):
-    def __init__(self):
-        super().__init__("Failed to vectorize data. Your input type is not yet supported.")
+    def __init__(self, append: str = ""):
+        msg = "Failed to vectorize data. Your input is not yet supported" + (": " if append else ".")
+        msg += (": " if append else ".") + append
+        super().__init__(msg)
+
+def process_dir(dir_path: Path, delete: bool = True) -> str:
+    # TODO
+    _, _ = dir_path, delete
+    raise NotSupportedError()
+
+def process_file(file_path: Path, delete: bool = False) -> str:
+    # TODO(justin): 
+    # - cache vector store id based on file hash
+    # - add archive support (.zip, .tar.gz) - extract, call process_dir
+    # - maybe add automatic extraction of text from pdf or html (undecided)
+    vector_store = ai.create_vector_store(file_path.stem, [file_path])
+    _ = delete and file_path.exists() and file_path.unlink()
+    return vector_store.id
+
+def process_url(url: str) -> str:
+    if youtube.is_url(url):
+        return youtube.process(url)
+
+    extensions = {
+        "text/plain": ".txt",
+        "application/pdf": ".pdf",
+        "text/html": ".html"
+    }
+
+    response = requests.head(url, allow_redirects = True)
+    response.raise_for_status()
+
+    result_url = response.url
+    content_type = response.headers.get("Content-Type", "")
+
+    valid_types = list(extensions.keys())
+    for ctype in valid_types:
+        if content_type.startswith(ctype):
+            content_type = ctype
+            break
+
+    if not content_type in valid_types:
+        raise NotSupportedError(f"\nUnsupported content type detected from HEAD request: {content_type}")
+    
+    # send requst to download file from url (stream the data)
+    response = requests.get(result_url, stream = True)
+    response.raise_for_status()
+    
+    # create temp file and write chunks of streamed data to disk
+    extension = extensions.get(content_type, ".txt")
+    temp_file = tempfile.NamedTemporaryFile(suffix = extension, delete = False)
+    try:
+        temp_file_path = Path(temp_file.name)
+        for chunk in response.iter_content(chunk_size = 8 * DataUnit.KB):
+            temp_file.write(chunk)
+    except Exception as ex:
+        raise RuntimeError(f"Failed to write bytes to temporary file: {ex}")
+    finally:
+        temp_file.close()
+
+    # process the temp file, automatically delete it after
+    try:
+        result = process_file(temp_file_path, delete = True)
+    finally:
+        if temp_file_path.exists():
+            temp_file_path.unlink()
+    return result
 
 def process_input(input_str: str) -> str:
     """Takes user input, attempts to return OpenAI VectorStore ID after processing data."""
+    path = Path(input_str)
+    if path.exists():
+        if path.is_file():
+            return process_file(path)
+        elif path.is_dir():
+            return process_dir(path)
+
     if validators.url(input_str):
-
-        # it's a URL
-        url = input_str
-
-        # youtube url handling
-        if youtube.is_url(url):
-            return youtube.process(url)
+        return process_url(input_str)
 
     raise NotSupportedError()
-
 
 def main():
     settings = init_settings()
@@ -30,6 +96,7 @@ def main():
     while True:
         # prompt user for data source
         input_str = input("Enter a URL or local file path: ")
+        input_str = input_str.strip('\'"')
 
         # handle early exit prompts
         if input_str.lower() in ["exit", "quit", ":q"]:
@@ -42,6 +109,9 @@ def main():
             break
         except NotSupportedError as ex:
             print(ex)
+            continue
+        except (requests.RequestException, requests.HTTPError) as ex:
+            print(f"An error occurred while sending a web request to the provided URL:\n{ex}")
             continue
         except Exception as ex:
             print(f"An unhandled error occurred while processing input:\n{ex}")

--- a/summawise/__main__.py
+++ b/summawise/__main__.py
@@ -1,9 +1,9 @@
 import ai, youtube, utils
-from settings import get_settings
+from settings import init_settings
 
 def main():
-    settings = get_settings()
     youtube_url = input("Enter a YouTube video URL: ")
+    settings = init_settings()
 
     if not hasattr(ai, "client"):
         # TODO(justin): handle api key that becomes invalid *after* initial setup prompts

--- a/summawise/ai.py
+++ b/summawise/ai.py
@@ -68,6 +68,7 @@ def create_vector_store(name: str, files: List[Path]) -> VectorStore:
     return vector_store
 
 def create_assistant(model: str) -> Assistant:
+    # TODO(justin): more generic instructions, since this program is for more than just video transcripts
     assistant = client.beta.assistants.create(
         name = "Transcript Analysis Assistant",
         instructions = "You are an assistant that summarizes video transcripts and answers questions about them.",

--- a/summawise/errors.py
+++ b/summawise/errors.py
@@ -1,0 +1,5 @@
+class NotSupportedError(Exception):
+    def __init__(self, append: str = ""):
+        msg = "Failed to vectorize data. Your input is not yet supported" + (": " if append else ".")
+        msg += (": " if append else ".") + append
+        super().__init__(msg)

--- a/summawise/filesystem.py
+++ b/summawise/filesystem.py
@@ -1,0 +1,17 @@
+import ai
+from pathlib import Path
+from errors import NotSupportedError
+
+def process_dir(dir_path: Path, delete: bool = True) -> str:
+    # TODO
+    _, _ = dir_path, delete
+    raise NotSupportedError()
+
+def process_file(file_path: Path, delete: bool = False) -> str:
+    # TODO(justin): 
+    # - cache vector store id based on file hash
+    # - add archive support (.zip, .tar.gz) - extract, call process_dir
+    # - maybe add automatic extraction of text from pdf or html (undecided)
+    vector_store = ai.create_vector_store(file_path.stem, [file_path])
+    _ = delete and file_path.exists() and file_path.unlink()
+    return vector_store.id

--- a/summawise/settings.py
+++ b/summawise/settings.py
@@ -1,5 +1,5 @@
 import json, utils, ai
-from utils import FileUtils
+from utils import FileUtils, Singleton
 from enum import Enum
 from dataclasses import dataclass, asdict, fields
 from typing import Dict, Any, ClassVar
@@ -20,7 +20,7 @@ class DataMode(Enum):
             raise ValueError(f"Unsupported DataMode: {self}")
 
 @dataclass
-class Settings:
+class Settings(metaclass = Singleton):
     api_key: str
     assistant_id: str
     model: str
@@ -30,6 +30,10 @@ class Settings:
     DEFAULT_MODEL: ClassVar[str] = "gpt-3.5-turbo"
     DEFAULT_COMPRESSION: ClassVar[bool] = True
     DEFAULT_DATA_MODE: ClassVar[DataMode] = DataMode.BIN
+
+    # NOTE(justin): This class functions as a singleton. Example usage anywhere:
+    # settings = Settings() # type: ignore (dismiss warnings related to required arguments)
+    # print(settings.to_dict()) # contains info established in main()
 
     @staticmethod
     def from_dict(data: Dict[str, Any]) -> "Settings":
@@ -45,7 +49,7 @@ class Settings:
         data["data_mode"] = self.data_mode.value
         return data
 
-def get_settings() -> Settings:
+def init_settings() -> Settings:
     settings_file = utils.get_summawise_dir() / "settings.json"
     if settings_file.exists():
         s_str = FileUtils.read_str(settings_file)

--- a/summawise/utils.py
+++ b/summawise/utils.py
@@ -4,6 +4,13 @@ from typing import TypeVar, Type
 
 T = TypeVar('T')
 
+class Singleton(type):
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
 class FileUtils:
 
     @staticmethod

--- a/summawise/utils.py
+++ b/summawise/utils.py
@@ -66,3 +66,23 @@ class FileUtils:
 def get_summawise_dir() -> Path:
     temp_dir = Path(tempfile.gettempdir())
     return temp_dir / "summawise"
+
+def bytes_to_str(sz_bytes: int) -> str:
+    assert sz_bytes >= 0, "num_bytes must be non-negative"
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size, uidx = sz_bytes, 0
+    while size >= 1024 and uidx < len(units) - 1:
+        size /= 1024.0
+        uidx += 1
+    return f"{size:.2f} {units[uidx]}"
+
+def fp(file_path: Path) -> Path:
+    """
+    Patch a given 'Path' object in a specific scenario:
+    The correct path is the same exact location, but with a .gz suffix, denoting gzip compression.
+    """
+    if not file_path.exists():
+        gz_path = file_path.with_suffix(file_path.suffix + ".gz")
+        if gz_path.exists():
+            return gz_path
+    return file_path

--- a/summawise/web.py
+++ b/summawise/web.py
@@ -1,0 +1,54 @@
+import requests, tempfile, youtube
+from filesystem import process_file
+from utils import DataUnit
+from pathlib import Path
+from errors import NotSupportedError
+
+def process_url(url: str) -> str:
+    if youtube.is_url(url):
+        return youtube.process(url)
+
+    extensions = {
+        "text/plain": ".txt",
+        "application/pdf": ".pdf",
+        "text/html": ".html"
+    }
+
+    response = requests.head(url, allow_redirects = True)
+    response.raise_for_status()
+
+    result_url = response.url
+    content_type = response.headers.get("Content-Type", "")
+
+    valid_types = list(extensions.keys())
+    for ctype in valid_types:
+        if content_type.startswith(ctype):
+            content_type = ctype
+            break
+
+    if not content_type in valid_types:
+        raise NotSupportedError(f"\nUnsupported content type detected from HEAD request: {content_type}")
+    
+    # send requst to download file from url (stream the data)
+    response = requests.get(result_url, stream = True)
+    response.raise_for_status()
+    
+    # create temp file and write chunks of streamed data to disk
+    extension = extensions.get(content_type, ".txt")
+    temp_file = tempfile.NamedTemporaryFile(suffix = extension, delete = False)
+    try:
+        temp_file_path = Path(temp_file.name)
+        for chunk in response.iter_content(chunk_size = 8 * DataUnit.KB):
+            temp_file.write(chunk)
+    except Exception as ex:
+        raise RuntimeError(f"Failed to write bytes to temporary file: {ex}")
+    finally:
+        temp_file.close()
+
+    # process the temp file, automatically delete it after
+    try:
+        result = process_file(temp_file_path, delete = True)
+    finally:
+        if temp_file_path.exists():
+            temp_file_path.unlink()
+    return result

--- a/summawise/youtube.py
+++ b/summawise/youtube.py
@@ -1,5 +1,5 @@
 import json, re, utils, ai
-from utils import FileUtils
+from utils import FileUtils, fp
 from settings import Settings, DataMode
 from datetime import timedelta
 from typing import List
@@ -109,25 +109,14 @@ def process(url: str) -> str:
     # use settings class (singleton)
     settings = Settings() # type: ignore
 
-    # get youtube video id
-    video_id = parse_video_id(url)
-    print(f"Extracted Video ID: {video_id}")
-    
     # file extension to cache certain ojects/data (json or bin)
     ext = settings.data_mode.ext()
 
+    video_id = parse_video_id(url)
     name = f"transcript_{video_id}"
-    transcript_path = utils.get_summawise_dir() / "youtube" / f"{name}.{ext}"
-    exists = transcript_path.exists()
+    transcript_path = fp(utils.get_summawise_dir() / "youtube" / f"{name}.{ext}")
 
-    if not exists and transcript_path.suffix != ".bin":
-        # check for gzipped variation of generated file path
-        gz_path = transcript_path.with_suffix(transcript_path.suffix + ".gz")
-        if gz_path.exists():
-            transcript_path = gz_path
-            exists = True
-
-    if not exists:
+    if not transcript_path.exists():
         # fetch transcript data from youtube
         try:
             transcript = get_transcript(video_id)


### PR DESCRIPTION
- Add support for local files (they get uploaded 1:1)
- Add support for URLs other than youtube, based on mapping Content-Type header to file extension.
Currently supports the following URL response content types:
```
 {
    "text/plain": ".txt",
    "application/pdf": ".pdf",
    "text/html": ".html"
}
```
**Note:** The key doesn't represent exactly what the Content-Type needs to be equal to, the check for validity/extension mapping occurs with `startswith`. For example, `"text/plain; charset=utf-8".startswith("text/plain")` evaluates to true,  so the response is considered valid and mapped to a .txt file.