### PR TITLE
Refactors in prep for pre-release v0.2.0 (better separation of concerns)

### DIFF
--- a/summawise/__main__.py
+++ b/summawise/__main__.py
@@ -1,13 +1,13 @@
 import validators, requests, time, sys
-from . import ai
-from .settings import init_settings
-from .web import process_url
-from .filesystem import process_file, process_dir
-from .utils import DataUnit
-from .errors import NotSupportedError
 from openai.types.beta import VectorStore 
 from typing import Optional
 from pathlib import Path
+from . import ai
+from .settings import init_settings
+from .web import process_url
+from .files.processing import process_file, process_dir
+from .data import DataUnit
+from .errors import NotSupportedError
 
 def main():
     settings = init_settings()

--- a/summawise/data.py
+++ b/summawise/data.py
@@ -1,0 +1,55 @@
+import inspect
+from enum import Enum
+from typing import List
+
+class DataMode(Enum):
+    JSON = "json"
+    BIN = "binary"
+
+    def ext(self) -> str:
+        extensions = {
+            DataMode.JSON: "json",
+            DataMode.BIN: "bin"
+        }
+        try:
+            return extensions[self]
+        except KeyError:
+            raise ValueError(f"Unsupported DataMode: {self}")
+
+class DataUnit:
+    __excludes__ = ["units"]
+
+    B: int = 1
+    KB: int = 2 ** 10
+    MB: int = 2 ** 20
+    GB: int = 2 ** 30
+    TB: int = 2 ** 40
+
+    units: List[str] = []
+
+    @staticmethod
+    def _get_units() -> List[str]:
+        # "B", "KB", "MB", "GB", "TB"
+        if len(DataUnit.units):
+            return DataUnit.units
+        units = [
+            (name, value) for name, value in inspect.getmembers(DataUnit) 
+            if not name.startswith("__") 
+            and name not in DataUnit.__excludes__ 
+            and not callable(value)
+        ]
+        units = sorted(units, key=lambda x: x[1])
+        DataUnit.units = [name for name, _ in units]
+        return DataUnit.units
+
+    @staticmethod
+    def bytes_to_str(sz_bytes: int) -> str:
+        assert sz_bytes >= 0, "sz_bytes must be non-negative"
+        size, uidx = sz_bytes, 0
+        units = DataUnit.units or DataUnit._get_units()
+        while size >= DataUnit.KB and uidx < len(units) - 1:
+            size /= float(DataUnit.KB)
+            uidx += 1
+        return f"{size:.2f} {units[uidx]}"
+
+

--- a/summawise/files/metadata.py
+++ b/summawise/files/metadata.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from pathlib import Path
+from . import utils as FileUtils
+from ..serializable import Serializable
+
+@dataclass
+class FileMetadata(Serializable):
+    hash: str
+    name: str
+    full_path: str
+    sz_bytes: int
+    created_at: float
+    last_modified_at: float
+    last_accessed_at: float
+    vector_store_id: str = ""
+
+    @classmethod
+    def create_from_path(cls, file_path: Path) -> "FileMetadata":
+        hash = FileUtils.calculate_hash(file_path)
+        stats = file_path.stat()
+        sz_bytes = stats.st_size
+        created_at = stats.st_ctime
+        last_modified_at = stats.st_mtime
+        last_accessed_at = stats.st_atime
+
+        return cls(hash, file_path.name, str(file_path), sz_bytes,
+                   created_at, last_modified_at, last_accessed_at)    
+

--- a/summawise/files/processing.py
+++ b/summawise/files/processing.py
@@ -1,34 +1,8 @@
-from . import ai, utils
-from .utils import fp
-from .files import utils as FileUtils
-from .serializable import Serializable
-from .errors import NotSupportedError
-from .settings import Settings
-from dataclasses import dataclass
 from pathlib import Path
-
-@dataclass
-class FileMetadata(Serializable):
-    hash: str
-    name: str
-    full_path: str
-    sz_bytes: int
-    created_at: float
-    last_modified_at: float
-    last_accessed_at: float
-    vector_store_id: str = ""
-
-    @classmethod
-    def create_from_path(cls, file_path: Path) -> "FileMetadata":
-        hash = FileUtils.calculate_hash(file_path)
-        stats = file_path.stat()
-        sz_bytes = stats.st_size
-        created_at = stats.st_ctime
-        last_modified_at = stats.st_mtime
-        last_accessed_at = stats.st_atime
-
-        return cls(hash, file_path.name, str(file_path), sz_bytes,
-                   created_at, last_modified_at, last_accessed_at)    
+from .metadata import FileMetadata
+from .. import ai, utils
+from ..errors import NotSupportedError
+from ..settings import Settings
 
 def process_dir(dir_path: Path, delete: bool = True) -> str:
     # TODO
@@ -48,7 +22,7 @@ def process_file(file_path: Path, delete: bool = False) -> str:
 
     metadata = FileMetadata.create_from_path(file_path)
     hash = metadata.hash
-    hash_path = fp(utils.get_summawise_dir() / "files" / f"{hash}.{ext}")
+    hash_path = utils.fp(utils.get_summawise_dir() / "files" / f"{hash}.{ext}")
 
     vector_store_id: str = ""
     if not hash_path.exists():

--- a/summawise/files/utils.py
+++ b/summawise/files/utils.py
@@ -1,0 +1,57 @@
+import pickle, gzip, hashlib
+from pathlib import Path
+from typing import TypeVar, Type
+from ..utils import DataUnit
+
+T = TypeVar("T")
+
+def write_str(file_path: Path, text: str, compress: bool = False) -> None:
+    file_path.parent.mkdir(parents = True, exist_ok = True)
+    data = text.encode("utf-8")
+    write_bytes(file_path, data, compress)
+
+def read_str(file_path: Path) -> str:
+    data = read_bytes(file_path)
+    text = data.decode("utf-8")
+    return text
+
+def write_bytes(file_path: Path, data: bytes, compress: bool = False) -> None:
+    file_path.parent.mkdir(parents = True, exist_ok = True)
+    if compress:
+        if file_path.suffix != ".bin" and ".gz" not in file_path.suffixes:
+            file_path = file_path.with_suffix(file_path.suffix + ".gz")
+        data = gzip.compress(data)
+    with open(file_path, 'wb') as file:
+        file.write(data)
+
+def read_bytes(file_path: Path) -> bytes:
+    with open(file_path, 'rb') as file:
+        data = file.read()
+    if ".gz" in file_path.suffixes or ".bin" in file_path.suffixes:
+        try:
+            data = gzip.decompress(data)
+        except gzip.BadGzipFile:
+            pass
+    return data
+
+def save_object(file_path: Path, obj: object, compress: bool = True) -> None:
+    data = pickle.dumps(obj)
+    write_bytes(file_path, data, compress)
+
+def load_object(file_path: Path, cls: Type[T]) -> T:
+    obj = load_object_any(file_path)
+    if not isinstance(obj, cls):
+        raise TypeError(f"Expected object of type {cls.__name__}, but got {type(obj).__name__}")
+    return obj
+
+def load_object_any(file_path: Path) -> object:
+    data = read_bytes(file_path)
+    return pickle.loads(data)
+
+def calculate_hash(file_path: Path) -> str:
+    hash = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        reader = lambda: f.read(8 * DataUnit.KB)
+        for chunk in iter(reader, b""):
+            hash.update(chunk)
+    return hash.hexdigest()

--- a/summawise/files/utils.py
+++ b/summawise/files/utils.py
@@ -1,7 +1,7 @@
 import pickle, gzip, hashlib
 from pathlib import Path
 from typing import TypeVar, Type
-from ..utils import DataUnit
+from ..data import DataUnit
 
 T = TypeVar("T")
 

--- a/summawise/filesystem.py
+++ b/summawise/filesystem.py
@@ -1,6 +1,7 @@
-import json
 from . import ai, utils
-from .utils import FileUtils, Serializable, fp
+from .utils import fp
+from .files import utils as FileUtils
+from .serializable import Serializable
 from .errors import NotSupportedError
 from .settings import Settings
 from dataclasses import dataclass

--- a/summawise/serializable.py
+++ b/summawise/serializable.py
@@ -1,0 +1,39 @@
+import json
+from .utils import DataMode
+from .files import utils as FileUtils
+from typing import TypeVar, Type
+from pathlib import Path
+from dataclasses import is_dataclass, asdict
+
+ST = TypeVar("ST", bound = "Serializable")
+
+class Serializable:
+
+    def save_to_file(self, file_path: Path, mode: DataMode = DataMode.JSON, compress: bool = False):
+        if mode == DataMode.JSON:
+            json_str = self.to_json()
+            FileUtils.write_str(file_path, json_str, compress)
+        elif mode == DataMode.BIN:
+            FileUtils.save_object(file_path, self, compress)
+
+    @classmethod
+    def from_file(cls: Type[ST], file_path: Path, mode: DataMode = DataMode.JSON) -> ST:
+        if mode == DataMode.JSON:
+            json_str = FileUtils.read_str(file_path)
+            return cls.from_json(json_str)
+        elif mode == DataMode.BIN:
+            return FileUtils.load_object(file_path, cls)
+
+    @classmethod
+    def from_json(cls: Type[ST], json_str: str) -> ST:
+        if not is_dataclass(cls):
+            raise NotImplementedError(f"Class '{cls.__name__}' is not a dataclass, so it must provide its own implementation of 'from_json'.")
+        # NOTE(justin): My LSP gives me a 'Code is unreachable' warning here, but that is not accurate.
+        # If a subclass extends 'Serializable' and has the '@dataclass' decorator, the above exception will not be raised.
+        data = json.loads(json_str)
+        return cls(**data)
+
+    def to_json(self, pretty: bool = False) -> str:
+        if not is_dataclass(self):
+            raise NotImplementedError(f"Class '{type(self).__name__}' is not a dataclass, so it must provide its own implementation of 'to_json'.")
+        return json.dumps(asdict(self), indent = 4 if pretty else None)

--- a/summawise/serializable.py
+++ b/summawise/serializable.py
@@ -1,9 +1,9 @@
 import json
-from .utils import DataMode
-from .files import utils as FileUtils
 from typing import TypeVar, Type
 from pathlib import Path
 from dataclasses import is_dataclass, asdict
+from .data import DataMode
+from .files import utils as FileUtils
 
 ST = TypeVar("ST", bound = "Serializable")
 

--- a/summawise/settings.py
+++ b/summawise/settings.py
@@ -1,10 +1,11 @@
 import json
-from . import utils, ai
-from .utils import Singleton, DataMode
-from .files import utils as FileUtils
 from dataclasses import dataclass, asdict, fields
 from typing import Dict, Any, ClassVar
 from openai import AuthenticationError, BadRequestError
+from . import utils, ai
+from .utils import Singleton
+from .data import DataMode
+from .files import utils as FileUtils
 
 @dataclass
 class Settings(metaclass = Singleton):

--- a/summawise/settings.py
+++ b/summawise/settings.py
@@ -1,6 +1,7 @@
 import json
 from . import utils, ai
-from .utils import FileUtils, Singleton, DataMode
+from .utils import Singleton, DataMode
+from .files import utils as FileUtils
 from dataclasses import dataclass, asdict, fields
 from typing import Dict, Any, ClassVar
 from openai import AuthenticationError, BadRequestError

--- a/summawise/utils.py
+++ b/summawise/utils.py
@@ -1,57 +1,5 @@
-import tempfile, inspect
+import tempfile
 from pathlib import Path
-from enum import Enum
-from typing import List
-
-class DataMode(Enum):
-    JSON = "json"
-    BIN = "binary"
-
-    def ext(self) -> str:
-        extensions = {
-            DataMode.JSON: "json",
-            DataMode.BIN: "bin"
-        }
-        try:
-            return extensions[self]
-        except KeyError:
-            raise ValueError(f"Unsupported DataMode: {self}")
-
-class DataUnit:
-    __excludes__ = ["units"]
-
-    B: int = 1
-    KB: int = 2 ** 10
-    MB: int = 2 ** 20
-    GB: int = 2 ** 30
-    TB: int = 2 ** 40
-
-    units: List[str] = []
-
-    @staticmethod
-    def _get_units() -> List[str]:
-        # "B", "KB", "MB", "GB", "TB"
-        if len(DataUnit.units):
-            return DataUnit.units
-        units = [
-            (name, value) for name, value in inspect.getmembers(DataUnit) 
-            if not name.startswith("__") 
-            and name not in DataUnit.__excludes__ 
-            and not callable(value)
-        ]
-        units = sorted(units, key=lambda x: x[1])
-        DataUnit.units = [name for name, _ in units]
-        return DataUnit.units
-
-    @staticmethod
-    def bytes_to_str(sz_bytes: int) -> str:
-        assert sz_bytes >= 0, "sz_bytes must be non-negative"
-        size, uidx = sz_bytes, 0
-        units = DataUnit.units or DataUnit._get_units()
-        while size >= DataUnit.KB and uidx < len(units) - 1:
-            size /= float(DataUnit.KB)
-            uidx += 1
-        return f"{size:.2f} {units[uidx]}"
 
 class Singleton(type):
     _instances = {}

--- a/summawise/utils.py
+++ b/summawise/utils.py
@@ -1,11 +1,7 @@
-import tempfile, pickle, gzip, inspect, hashlib, json
+import tempfile, inspect
 from pathlib import Path
 from enum import Enum
-from typing import List, TypeVar, Type
-from dataclasses import dataclass, is_dataclass, asdict
-
-T = TypeVar("T")
-ST = TypeVar("ST", bound = "Serializable")
+from typing import List
 
 class DataMode(Enum):
     JSON = "json"
@@ -63,98 +59,6 @@ class Singleton(type):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
-
-class Serializable:
-
-    def save_to_file(self, file_path: Path, mode: DataMode = DataMode.JSON, compress: bool = False):
-        if mode == DataMode.JSON:
-            json_str = self.to_json()
-            FileUtils.write_str(file_path, json_str, compress)
-        elif mode == DataMode.BIN:
-            FileUtils.save_object(file_path, self, compress)
-
-    @classmethod
-    def from_file(cls: Type[ST], file_path: Path, mode: DataMode = DataMode.JSON) -> ST:
-        if mode == DataMode.JSON:
-            json_str = FileUtils.read_str(file_path)
-            return cls.from_json(json_str)
-        elif mode == DataMode.BIN:
-            return FileUtils.load_object(file_path, cls)
-
-    @classmethod
-    def from_json(cls: Type[ST], json_str: str) -> ST:
-        if not is_dataclass(cls):
-            raise NotImplementedError(f"Class '{cls.__name__}' is not a dataclass, so it must provide its own implementation of 'from_json'.")
-        # NOTE(justin): My LSP gives me a 'Code is unreachable' warning here, but that is not accurate.
-        # If a subclass extends 'Serializable' and has the '@dataclass' decorator, the above exception will not be raised.
-        data = json.loads(json_str)
-        return cls(**data)
-
-    def to_json(self, pretty: bool = False) -> str:
-        if not is_dataclass(self):
-            raise NotImplementedError(f"Class '{type(self).__name__}' is not a dataclass, so it must provide its own implementation of 'to_json'.")
-        return json.dumps(asdict(self), indent = 4 if pretty else None)
-
-class FileUtils:
-
-    @staticmethod
-    def write_str(file_path: Path, text: str, compress: bool = False) -> None:
-        file_path.parent.mkdir(parents = True, exist_ok = True)
-        data = text.encode("utf-8")
-        FileUtils.write_bytes(file_path, data, compress)
-
-    @staticmethod
-    def read_str(file_path: Path) -> str:
-        data = FileUtils.read_bytes(file_path)
-        text = data.decode("utf-8")
-        return text
-
-    @staticmethod
-    def write_bytes(file_path: Path, data: bytes, compress: bool = False) -> None:
-        file_path.parent.mkdir(parents = True, exist_ok = True)
-        if compress:
-            if file_path.suffix != ".bin" and ".gz" not in file_path.suffixes:
-                file_path = file_path.with_suffix(file_path.suffix + ".gz")
-            data = gzip.compress(data)
-        with open(file_path, 'wb') as file:
-            file.write(data)
-
-    @staticmethod
-    def read_bytes(file_path: Path) -> bytes:
-        with open(file_path, 'rb') as file:
-            data = file.read()
-        if ".gz" in file_path.suffixes or ".bin" in file_path.suffixes:
-            try:
-                data = gzip.decompress(data)
-            except gzip.BadGzipFile:
-                pass
-        return data
-
-    @staticmethod
-    def save_object(file_path: Path, obj: object, compress: bool = True) -> None:
-        data = pickle.dumps(obj)
-        FileUtils.write_bytes(file_path, data, compress)
-
-    @staticmethod
-    def load_object(file_path: Path, cls: Type[T]) -> T:
-        obj = FileUtils.load_object_any(file_path)
-        if not isinstance(obj, cls):
-            raise TypeError(f"Expected object of type {cls.__name__}, but got {type(obj).__name__}")
-        return obj
-
-    @staticmethod
-    def load_object_any(file_path: Path) -> object:
-        data = FileUtils.read_bytes(file_path)
-        return pickle.loads(data)
-
-    @staticmethod
-    def calculate_hash(file_path: Path) -> str:
-        hash = hashlib.sha256()
-        with open(file_path, "rb") as f:
-            reader = lambda: f.read(8 * DataUnit.KB)
-            for chunk in iter(reader, b""):
-                hash.update(chunk)
-        return hash.hexdigest()
 
 def get_summawise_dir() -> Path:
     temp_dir = Path(tempfile.gettempdir())

--- a/summawise/web.py
+++ b/summawise/web.py
@@ -1,9 +1,9 @@
 import requests, tempfile
-from . import youtube
-from .filesystem import process_file
-from .utils import DataUnit
-from .errors import NotSupportedError
 from pathlib import Path
+from . import youtube
+from .files.processing import process_file
+from .data import DataUnit
+from .errors import NotSupportedError
 
 def process_url(url: str) -> str:
     if youtube.is_url(url):

--- a/summawise/youtube.py
+++ b/summawise/youtube.py
@@ -1,6 +1,8 @@
 import json, re
 from . import utils, ai
-from .utils import DataMode, FileUtils, Serializable, fp
+from .utils import DataMode, fp
+from .files import utils as FileUtils
+from .serializable import Serializable
 from .settings import Settings
 from datetime import timedelta
 from typing import List

--- a/summawise/youtube.py
+++ b/summawise/youtube.py
@@ -1,13 +1,13 @@
 import json, re
-from . import utils, ai
-from .utils import DataMode, fp
-from .files import utils as FileUtils
-from .serializable import Serializable
-from .settings import Settings
 from datetime import timedelta
 from typing import List
 from pathlib import Path
 from youtube_transcript_api import YouTubeTranscriptApi
+from . import utils, ai
+from .data import DataMode
+from .files import utils as FileUtils
+from .serializable import Serializable
+from .settings import Settings
 
 class TranscriptEntry:
 
@@ -102,7 +102,7 @@ def process_url(url: str) -> str:
 
     video_id = parse_video_id(url)
     name = f"transcript_{video_id}"
-    transcript_path = fp(utils.get_summawise_dir() / "youtube" / f"{name}.{ext}")
+    transcript_path = utils.fp(utils.get_summawise_dir() / "youtube" / f"{name}.{ext}")
 
     if not transcript_path.exists():
         # fetch transcript data from youtube


### PR DESCRIPTION
- Created `data.py` file to encapsulate `DataMode` and `DataUnit` classes.
  - `DataMode`: Enum which represents formats in which objects are serialized/stored on disk for caching purpose, either as `.json` or `.bin` files.
  - `DataUnit`: Encapsulates some logic related to data storage units for code readability elsewhere, and a helper func to represent a number of bytes in a human-friendly readable way.
- Created `serializable.py` file for the `Serializable` class, which serves as a base class for objects that need to be serialized/saved to disk. This would be pickled binary data or serialized as JSON, depending on the `DataMode` setting.
- Created `files` directory with the following files:
  - `files/utils.py`: Contains helper funcs that were previously encapsulated as static methods in the `FileUtils` class of generic `utils.py` file. Functionality is still accessed the same way. (ex: `from .files import utils as FileUtils`
  - `files/metadata.py`: Contains the `FileMetadata` class. This is a subclass of `Serialized` and is also a dataclass, which means that all functionality can be inherited from `Serialized` without overrides. (non-dataclass subclasses of `Serialized` require their own implementation of `to_json` and `from_json`.)
  - `files/processing.py`: Contains the processing funcs `process_dir` and `process_file` (previously in `filesystem.py`) which are responsible for processing data, vectorizing it, and returning the vector store ID.