### PR TITLE
Implement custom assistants, CLI supports

### DIFF
--- a/summawise/ai.py
+++ b/summawise/ai.py
@@ -56,10 +56,13 @@ def init(api_key: str, verify: bool = True):
     """
     if not api_key or not isinstance(api_key, str):
         raise ValueError("API key must be a non-empty string.")
-    
+
     global Client
-    Client = OpenAI(api_key = api_key)
+    if "Client" in globals():
+        if Client.api_key == api_key:
+            return
     
+    Client = OpenAI(api_key = api_key)
     if verify:
         Client.models.list()
 

--- a/summawise/ai.py
+++ b/summawise/ai.py
@@ -140,6 +140,9 @@ def create_assistant(
     )
     return assistant
 
+def get_assistant(id: str) -> Assistant:
+    return Client.beta.assistants.retrieve(id)
+
 def create_thread(vector_store_ids: List[str]) -> Thread:
     thread = Client.beta.threads.create(
         tool_resources = {"file_search": {"vector_store_ids": vector_store_ids}}

--- a/summawise/assistants.py
+++ b/summawise/assistants.py
@@ -1,7 +1,11 @@
-from typing import List, Optional
-from dataclasses import dataclass, asdict
+from typing import List, Optional, Iterable, Callable, TypeVar
+from datetime import datetime, timezone
+from dataclasses import dataclass, asdict, field
 from . import utils
-from .errors import MultipleAssistantsFoundException
+from .errors import MultipleAssistantsFoundError, MissingSortKeyError
+from openai.types.beta import Assistant as APIAssistant
+
+T = TypeVar('T')
 
 DEFAULT_MODEL = "gpt-3.5-turbo"
 
@@ -25,6 +29,17 @@ class Assistant:
     
     def to_create_params(self) -> dict:
         return utils.asdict_exclude(self, {"id", "created_at"})
+
+    def apply_api_obj(self, obj: APIAssistant):
+        """Use official library API object to apply/overwrite specific fields to this dataclass."""
+        self.id = obj.id
+        self.name = obj.name or ""
+        self.instructions = obj.instructions or ""
+        self.model = obj.model
+        self.description = obj.description
+        self.top_p = obj.top_p
+        self.temperature = obj.temperature
+        self.created_at = datetime.fromtimestamp(obj.created_at, timezone.utc)
 
 class AssistantList(List[Assistant]):
 

--- a/summawise/assistants.py
+++ b/summawise/assistants.py
@@ -1,6 +1,7 @@
-from typing import List, Set, Optional
+from typing import List, Optional
 from dataclasses import dataclass, asdict
 from . import utils
+from .errors import MultipleAssistantsFoundException
 
 DEFAULT_MODEL = "gpt-3.5-turbo"
 
@@ -22,6 +23,22 @@ class Assistant:
     
     def to_create_params(self) -> dict:
         return utils.asdict_exclude(self, {"id"})
+
+class AssistantList(List[Assistant]):
+
+    def to_dict_list(self) -> List[dict]:
+        return [a.to_dict() for a in self]
+
+    def list_by_name(self, name: str) -> List[Assistant]:
+        return [assistant for assistant in self if assistant.name == name]
+
+    def get_by_name(self, name: str, default: Optional[Assistant] = None) -> Optional[Assistant]:
+        assistants = self.list_by_name(name)
+        if len(assistants) == 0:
+            return default
+        if len(assistants) > 1:
+            raise MultipleAssistantsFoundException("name", name)
+        return assistants[0]
 
 TranscriptAnalyzer: Assistant = Assistant(
     name = "Transcript Analysis Assistant",

--- a/summawise/assistants.py
+++ b/summawise/assistants.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List, Optional, Iterable, Callable, TypeVar
 from datetime import datetime, timezone
 from dataclasses import dataclass, asdict, field
@@ -11,10 +12,10 @@ DEFAULT_MODEL = "gpt-3.5-turbo"
 
 @dataclass
 class Assistant:
-    name: str
-    instructions: str
-    model: str = DEFAULT_MODEL
     id: str = ""
+    name: str = ""
+    instructions: str = ""
+    model: str = DEFAULT_MODEL
     file_search: bool = False
     interpret_code: bool = False
     respond_with_json: bool = False
@@ -22,6 +23,11 @@ class Assistant:
     temperature: Optional[float] = None
     top_p: Optional[float] = None
     created_at: datetime = field(default_factory = utils.utc_now)
+
+    def __post_init__(self):
+        missing_field_warning = lambda x: warnings.warn(f"'Assistant' object is missing expected field {x}.\nThis field should always be provided.", UserWarning)
+        if not self.name: missing_field_warning("name")
+        if not self.instructions: missing_field_warning("instructions")
 
     def to_dict(self) -> dict:
         obj = asdict(self)

--- a/summawise/assistants.py
+++ b/summawise/assistants.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional, Iterable, Callable, TypeVar
+from typing import List, Optional, Iterable, Callable, TypeVar, Tuple
 from datetime import datetime, timezone
 from dataclasses import dataclass, asdict, field
 from . import utils
@@ -57,6 +57,8 @@ class AssistantList(List[Assistant]):
         reverse: bool = False
     ):
         if not sort:
+            # sort by "created_at" by default (consistency allows use of index as identifier)
+            assistants = sorted(assistants, key = lambda a: a.created_at) # type: ignore
             super().__init__(assistants)
             return
 
@@ -85,6 +87,12 @@ class AssistantList(List[Assistant]):
         if len(assistants) > 1:
             raise MultipleAssistantsFoundError("name", name)
         return assistants[0]
+
+    def get_by_id(self, id: str) -> Tuple[Optional[Assistant], int]:
+        for idx, assistant in enumerate(self):
+            if assistant.id == id:
+                return assistant, idx
+        return None, -1
 
 TranscriptAnalyzer: Assistant = Assistant(
     name = "Transcript Analysis Assistant",

--- a/summawise/assistants.py
+++ b/summawise/assistants.py
@@ -74,11 +74,12 @@ class AssistantList(List[Assistant]):
         assistants = [Assistant(**obj) for obj in objects]
         return AssistantList(assistants, **kwargs)
 
-    def list_by_name(self, name: str) -> List[Assistant]:
-        return [assistant for assistant in self if assistant.name == name]
+    def list_by_name(self, name: str, case_sensitive: bool = False) -> List[Assistant]:
+        t = lambda s: s if case_sensitive else s.lower() # transform func
+        return [assistant for assistant in self if t(assistant.name) == t(name)]
 
-    def get_by_name(self, name: str, default: Optional[Assistant] = None) -> Optional[Assistant]:
-        assistants = self.list_by_name(name)
+    def get_by_name(self, name: str, default: Optional[Assistant] = None, case_sensitive: bool = False) -> Optional[Assistant]:
+        assistants = self.list_by_name(name, case_sensitive = case_sensitive)
         if len(assistants) == 0:
             return default
         if len(assistants) > 1:

--- a/summawise/assistants.py
+++ b/summawise/assistants.py
@@ -47,7 +47,7 @@ class AssistantList(List[Assistant]):
         self, 
         assistants: Iterable[Assistant] = [], 
         sort: bool = False,
-        key: Optional[Callable[[Assistant], T]] = None, 
+        key: Optional[Callable[[Assistant], T]] = None,
         reverse: bool = False
     ):
         if not sort:
@@ -62,6 +62,11 @@ class AssistantList(List[Assistant]):
 
     def to_dict_list(self) -> List[dict]:
         return [a.to_dict() for a in self]
+
+    @staticmethod
+    def from_dict_list(objects: List[dict], **kwargs) -> "AssistantList":
+        assistants = [Assistant(**obj) for obj in objects]
+        return AssistantList(assistants, **kwargs)
 
     def list_by_name(self, name: str) -> List[Assistant]:
         return [assistant for assistant in self if assistant.name == name]

--- a/summawise/assistants.py
+++ b/summawise/assistants.py
@@ -1,5 +1,6 @@
-from typing import List, Optional
-from dataclasses import dataclass
+from typing import List, Set, Optional
+from dataclasses import dataclass, asdict
+from . import utils
 
 DEFAULT_MODEL = "gpt-3.5-turbo"
 
@@ -14,6 +15,13 @@ class Assistant:
     description: Optional[str] = None
     temperature: Optional[float] = None
     top_p: Optional[float] = None
+    id: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+    
+    def to_create_params(self) -> dict:
+        return utils.asdict_exclude(self, {"id"})
 
 TranscriptAnalyzer: Assistant = Assistant(
     name = "Transcript Analysis Assistant",

--- a/summawise/commands/assistants.py
+++ b/summawise/commands/assistants.py
@@ -1,5 +1,4 @@
 import click
-from typing import Dict
 from ..settings import Settings
 
 @click.group()

--- a/summawise/commands/assistants.py
+++ b/summawise/commands/assistants.py
@@ -1,6 +1,6 @@
 import click
 from typing import Optional
-from .. import ai
+from .. import ai, utils
 from ..assistants import Assistant
 from ..settings import Settings
 
@@ -69,6 +69,33 @@ def create(
 @assistant.command()
 @click.argument("assistant_id", type = str)
 def delete(assistant_id: str):
-    """Delete an assistant."""
-    # TODO(justin): implement the logic to delete an assistant
-    print(f"summawise 'assistant delete' not yet implemented. (id: {assistant_id})")
+    """
+    Delete an assistant.\n
+    Provided ID can be the assistant name, id, or number from 'list'.
+    """
+    settings = Settings() # type: ignore
+    idx = -1
+
+    if assistant_id.startswith("asst_"):
+        _, idx = settings.assistants.get_by_id(assistant_id)
+        if idx == -1:
+            print("Failed to identify assistant to delete.")
+            return
+
+    if idx == -1:
+        assistant = settings.assistants.get_by_name(assistant_id)
+        if assistant:
+            _, idx = settings.assistants.get_by_id(assistant.id)
+
+    if idx == -1:
+        idx = utils.try_parse_int(assistant_id)
+        idx = -1 if idx is None else idx - 1
+
+    if idx < 0 or idx > len(settings.assistants) - 1:
+        print("Failed to identify assistant to delete.")
+        return
+
+    assistant = settings.assistants[idx]
+    del settings.assistants[idx]
+    settings.save()
+    print(f"Deleted assistant successfully: {assistant.name}")

--- a/summawise/commands/assistants.py
+++ b/summawise/commands/assistants.py
@@ -11,10 +11,8 @@ def assistant():
 def list():
     """List your available assistants."""
     settings = Settings() # type: ignore
-    assistant_choices: Dict[int, str] = {}
-    for idx, name in enumerate(settings.assistants.keys(), start = 1):
-        assistant_choices[idx] = name
-        print(f"{idx}) {name}")
+    for idx, assistant in enumerate(settings.assistants, start = 1):
+        print(f"{idx}) {assistant.name}")
 
 @assistant.command()
 @click.argument("name", type = str)

--- a/summawise/commands/assistants.py
+++ b/summawise/commands/assistants.py
@@ -1,9 +1,20 @@
 import click
+from typing import Dict
+from ..settings import Settings
 
 @click.group()
 def assistant():
     """Commands related to managing assistants."""
     pass
+
+@assistant.command()
+def list():
+    """List your available assistants."""
+    settings = Settings() # type: ignore
+    assistant_choices: Dict[int, str] = {}
+    for idx, name in enumerate(settings.assistants.keys(), start = 1):
+        assistant_choices[idx] = name
+        print(f"{idx}) {name}")
 
 @assistant.command()
 @click.argument("name", type = str)

--- a/summawise/commands/assistants.py
+++ b/summawise/commands/assistants.py
@@ -1,4 +1,7 @@
 import click
+from typing import Optional
+from .. import ai
+from ..assistants import Assistant
 from ..settings import Settings
 
 @click.group()
@@ -14,11 +17,54 @@ def list():
         print(f"{idx}) {assistant.name}")
 
 @assistant.command()
-@click.argument("name", type = str)
-def add(name: str):
+@click.option("-n", "--name", prompt = True, help = "The name of the assistant.")
+@click.option("-i", "--instructions", prompt = True, help = "Instructions for the assistant.")
+@click.option("-m", "--model", default = None, help = "The model to use.")
+@click.option("-d", "--description", default = None, help = "Description of the assistant.")
+@click.option("-fs", "--file_search", is_flag = True, help = "Enable file search capability.")
+@click.option("-ic", "--interpret_code", is_flag = True, help = "Enable code interpretation capability.")
+@click.option("-rwj", "--respond_with_json", is_flag = True, help = "Responses should be in valid JSON format.")
+@click.option("--temperature", default = None, type = float, help = "Temperature setting for the model.")
+@click.option("--top_p", default = None, type = float, help = "Top-p setting for the model.")
+def create(
+    name: str,
+    instructions: str,
+    file_search: bool,
+    interpret_code: bool,
+    respond_with_json: bool,
+    model: Optional[str],
+    description: Optional[str],
+    temperature: Optional[float],
+    top_p: Optional[float]
+) -> None:
     """Create a new assistant."""
-    # TODO(justin): implement the logic to create an assistant
-    print(f"summawise 'assistant add' not yet implemented. (name: {name})")
+    settings = Settings() # type: ignore
+
+    assistant = settings.assistants.get_by_name(name)
+    if assistant:
+        print("An assistant with that name already exists.")
+        return
+
+    model = model or settings.model
+    assistant = Assistant(
+        model = model,
+        name = name,
+        instructions = instructions,
+        file_search = file_search,
+        interpret_code = interpret_code,
+        respond_with_json = respond_with_json,
+        description = description,
+        temperature = temperature,
+        top_p = top_p
+    )
+
+    api_assistant = ai.create_assistant(**assistant.to_create_params())
+    assistant.apply_api_obj(api_assistant)
+    settings.assistants.append(assistant)
+    settings.save()
+
+    print(f"Your new assistant has been created successfully.\nName: {name}\nID: {assistant.id}")
+    return
 
 @assistant.command()
 @click.argument("assistant_id", type = str)

--- a/summawise/commands/scan.py
+++ b/summawise/commands/scan.py
@@ -56,21 +56,23 @@ def scan(user_input: Tuple[str, ...]):
 
     if len(settings.assistants) > 1:
         # list assistant choices, map numeric index to name
-        assistant_choices: Dict[int, str] = {}
-        for idx, name in enumerate(settings.assistants.keys(), start = 1):
-            assistant_choices[idx] = name
+        assistant_choices: Dict[int, Assistant] = {}
+        for idx, assistant in enumerate(settings.assistants, start = 1):
+            assistant_choices[idx] = assistant
             print(f"{idx}) {name}")
 
         # prompt user to select assistant 
-        assistant_name, assistant_id = "", ""
+        assistant_id = ""
+        assistant: Optional[Assistant] = None
         while not (assistant_id and assistant_name):
             choice = int(prompt("Select an assistant: ", validator = NumericChoiceValidator(assistant_choices.keys())))
-            assistant_name = assistant_choices[choice]
-            assistant_id = settings.assistants[assistant_name]
+            # assistant_id = settings.assistants[assistant_name]
+            assistant = assistant_choices[choice]
+            assistant_id = assistant.id
 
         # remove assistant selection menu, output valid choice
         delete_lines(len(assistant_choices) + 2)
-        print(f"Using selected assistant: {assistant_name}")
+        print(f"Using selected assistant: {assistant.name}")
     else:
         assistant_id = next(iter(settings.assistants.values()))
 

--- a/summawise/commands/scan.py
+++ b/summawise/commands/scan.py
@@ -19,9 +19,6 @@ def scan(user_input: Tuple[str, ...]):
     settings = Settings() # type: ignore
     FileCache.init()
 
-    if not hasattr(ai, "Client"):
-        ai.init(settings.api_key, verify=False)
-
     while True:
         # prompt user for data source if not provided as an argument
         if user_input:

--- a/summawise/commands/scan.py
+++ b/summawise/commands/scan.py
@@ -5,6 +5,7 @@ from prompt_toolkit import prompt
 from pathlib import Path
 from .. import ai
 from ..settings import Settings
+from ..assistants import Assistant
 from ..web import process_url
 from ..files.processing import process_file, process_dir
 from ..files import cache as FileCache
@@ -56,12 +57,12 @@ def scan(user_input: Tuple[str, ...]):
         assistant_choices: Dict[int, Assistant] = {}
         for idx, assistant in enumerate(settings.assistants, start = 1):
             assistant_choices[idx] = assistant
-            print(f"{idx}) {name}")
+            print(f"{idx}) {assistant.name}")
 
         # prompt user to select assistant 
         assistant_id = ""
         assistant: Optional[Assistant] = None
-        while not (assistant_id and assistant_name):
+        while not (assistant_id and assistant):
             choice = int(prompt("Select an assistant: ", validator = NumericChoiceValidator(assistant_choices.keys())))
             # assistant_id = settings.assistants[assistant_name]
             assistant = assistant_choices[choice]

--- a/summawise/commands/scan.py
+++ b/summawise/commands/scan.py
@@ -4,10 +4,10 @@ from typing import Tuple, Dict, Optional
 from prompt_toolkit import prompt
 from pathlib import Path
 from .. import ai
+from ..settings import Settings
 from ..web import process_url
 from ..files.processing import process_file, process_dir
 from ..files import cache as FileCache
-from ..settings import init_settings
 from ..errors import NotSupportedError
 from ..utils import NumericChoiceValidator, delete_lines
 from ..data import DataUnit
@@ -16,7 +16,7 @@ from ..data import DataUnit
 @click.argument("user_input", nargs = -1)
 def scan(user_input: Tuple[str, ...]):
     """Scan and process the given input (URL or file path), and offer an interactive prompt to inquire about the vectorized data."""
-    settings = init_settings()
+    settings = Settings() # type: ignore
     FileCache.init()
 
     if not hasattr(ai, "Client"):

--- a/summawise/commands/scan.py
+++ b/summawise/commands/scan.py
@@ -74,7 +74,7 @@ def scan(user_input: Tuple[str, ...]):
         delete_lines(len(assistant_choices) + 2)
         print(f"Using selected assistant: {assistant.name}")
     else:
-        assistant_id = next(iter(settings.assistants.values()))
+        assistant_id = settings.assistants[0].id
 
     # verify vector store validity w/ openai, output some generic info
     processing: bool = True

--- a/summawise/errors.py
+++ b/summawise/errors.py
@@ -29,3 +29,7 @@ class ValueTypeError(Exception):
 
         msg += f"but instead received value of type '{type(value).__name__}': {value}"
         super().__init__(msg)
+
+class MultipleAssistantsFoundException(Exception):
+    def __init__(self, condition: str, value: str):
+        super().__init__(f"Multiple assistants found. (Condition: '{condition}', Value: '{value}')")

--- a/summawise/errors.py
+++ b/summawise/errors.py
@@ -30,6 +30,12 @@ class ValueTypeError(Exception):
         msg += f"but instead received value of type '{type(value).__name__}': {value}"
         super().__init__(msg)
 
-class MultipleAssistantsFoundException(Exception):
+class MultipleAssistantsFoundError(Exception):
     def __init__(self, condition: str, value: str):
         super().__init__(f"Multiple assistants found. (Condition: '{condition}', Value: '{value}')")
+
+class MissingSortKeyError(Exception):
+    def __init__(self, append = ""):
+        msg = "Missing required sort key" + (": " if len(append) else ".") + append
+        super().__init__(msg)
+

--- a/summawise/main.py
+++ b/summawise/main.py
@@ -1,6 +1,6 @@
 import click, sys
 from .commands import scan, assistant
-from .settings import init_settings
+from .settings import Settings
 
 CONTEXT_SETTINGS = {"max_content_width": sys.maxsize}
 
@@ -14,6 +14,6 @@ def register_commands():
     cli.add_command(assistant)
 
 def main():
-    init_settings()
+    Settings.init()
     register_commands()
     cli()

--- a/summawise/main.py
+++ b/summawise/main.py
@@ -1,5 +1,6 @@
 import click, sys
 from .commands import scan, assistant
+from .settings import init_settings
 
 CONTEXT_SETTINGS = {"max_content_width": sys.maxsize}
 
@@ -10,8 +11,9 @@ def cli():
 
 def register_commands():
     cli.add_command(scan)
-    # cli.add_command(assistant) # not ready yet
+    cli.add_command(assistant)
 
 def main():
+    init_settings()
     register_commands()
     cli()

--- a/summawise/settings.py
+++ b/summawise/settings.py
@@ -63,7 +63,7 @@ def init_settings() -> Settings:
 
     # automatically create default assistants added in future versions
     for da in DEFAULT_ASSISTANTS:
-        if not da.name in "assistant":
+        if not da.name in settings.assistants:
             if not hasattr(ai, "Client"):
                 ai.init(settings.api_key, verify = False)
             assistant = ai.create_assistant(**asdict(da))

--- a/summawise/settings.py
+++ b/summawise/settings.py
@@ -41,7 +41,6 @@ class Settings(metaclass = Singleton):
         if assistant_id:
             default_assistant = copy.copy(DEFAULT_ASSISTANTS[0])
             default_assistant.id = assistant_id
-            # assistants[default_assistant.name] = default_assistant
             assistants.append(default_assistant)
 
         return Settings(
@@ -116,7 +115,6 @@ def prompt_for_settings() -> Settings:
         assistant = ai.create_assistant(**da.to_create_params())
         da.id = assistant.id
         assistants.append(da)
-        # assistants.append(assistant) # type: ignore[reportUnboundVariable]
 
     # TODO(justin): maybe add ability to select data mode. possibly a cli option to re-configure settings too.
     # it's not too important, for now it'll default to binary and can be changed manually.

--- a/summawise/settings.py
+++ b/summawise/settings.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
 from . import utils, ai
-from .utils import Singleton, classproperty
+from .utils import Singleton
 from .data import DataMode
 from .files import utils as FileUtils
 from .assistants import DEFAULT_ASSISTANTS, DEFAULT_MODEL, Assistant, AssistantList
@@ -28,10 +28,6 @@ class Settings(metaclass = Singleton):
     # NOTE(justin): This class functions as a singleton. Example usage anywhere:
     # settings = Settings() # type: ignore (dismiss warnings related to required arguments)
     # print(settings.to_dict()) # contains info established in main()
-
-    @classproperty
-    def file(cls) -> Path:
-        return utils.get_summawise_dir() / "settings.json"
 
     @staticmethod
     def from_dict(data: Dict[str, Any]) -> Tuple["Settings", bool]:
@@ -83,7 +79,7 @@ class Settings(metaclass = Singleton):
 
     @staticmethod
     def init() -> "Settings":
-        file = Settings.file
+        file = Settings.file()
         if file.exists():
             s_str = FileUtils.read_str(file)
             s_dict = json.loads(s_str)
@@ -114,8 +110,12 @@ class Settings(metaclass = Singleton):
     def save() -> "Settings":
         settings = Settings() # type: ignore
         s_str = json.dumps(settings.to_dict(), indent = 4)
-        FileUtils.write_str(Settings.file, s_str)
+        FileUtils.write_str(Settings.file(), s_str)
         return settings
+    
+    @staticmethod
+    def file() -> Path:
+        return utils.get_summawise_dir() / "settings.json"
 
     @staticmethod
     def prompt() -> "Settings":
@@ -131,6 +131,7 @@ class Settings(metaclass = Singleton):
         model_completer = WordCompleter(["gpt-4o", "gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"])
         while True:
             try:
+                # TODO(justin): add validator to this prompt
                 model = prompt(f"Enter the OpenAI model to use [Default: {Settings.DEFAULT_MODEL}]: ", completer = model_completer)
                 break
             except BadRequestError as ex:

--- a/summawise/settings.py
+++ b/summawise/settings.py
@@ -1,6 +1,6 @@
-import json, os
-from dataclasses import dataclass, asdict, fields, field
-from typing import Set, List, Union, Dict, Any, ClassVar
+import json, os, copy
+from dataclasses import dataclass, fields, field
+from typing import Set, Union, Dict, Any, ClassVar
 from openai import AuthenticationError, BadRequestError
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
@@ -14,7 +14,7 @@ from .assistants import DEFAULT_ASSISTANTS, DEFAULT_MODEL, Assistant
 class Settings(metaclass = Singleton):
     api_key: str
     assistant_id: str = field(repr = False) # NOTE(justin): deprecated in version 0.3.0
-    assistants: Dict[str, str]
+    assistants: Dict[str, Assistant]
     model: str
     compression: bool
     data_mode: DataMode
@@ -30,11 +30,18 @@ class Settings(metaclass = Singleton):
 
     @staticmethod
     def from_dict(data: Dict[str, Any]) -> "Settings":
+        assistants = data.pop("assistants", {})
+
+        # turn assistant dicts into object oriented representations
+        for name, obj in assistants.items():
+            assistants[name] = Assistant(**obj)
+
         # version 0.3.0 backwards compatability (adding multi-assistant support)
         assistant_id = data.pop("assistant_id", None)
-        assistants = data.pop("assistants", {})
         if assistant_id:
-            assistants[DEFAULT_ASSISTANTS[0].name] = assistant_id
+            default_assistant = copy.copy(DEFAULT_ASSISTANTS[0])
+            default_assistant.id = assistant_id
+            assistants[default_assistant.name] = default_assistant
 
         return Settings(
             assistant_id = assistant_id,
@@ -47,6 +54,7 @@ class Settings(metaclass = Singleton):
 
     def to_dict(self) -> Dict[str, Any]:
         data = utils.asdict_exclude(self, Settings.DEPRECATED_FIELDS)
+        data["assistants"] = {a.name: a.to_dict() for a in self.assistants.values()}
         data["data_mode"] = self.data_mode.value
         return data
 
@@ -66,9 +74,11 @@ def init_settings() -> Settings:
         if not da.name in settings.assistants:
             if not hasattr(ai, "Client"):
                 ai.init(settings.api_key, verify = False)
-            assistant = ai.create_assistant(**asdict(da))
+            da = copy.copy(da)
+            assistant = ai.create_assistant(**da.to_create_params())
             assert assistant.name # NOTE(justin): OpenAI Assistant type has this field as optional, but we require it for identification
-            settings.assistants[assistant.name] = assistant.id
+            da.id = assistant.id
+            settings.assistants[assistant.name] = da
             save = True
                 
     if save:
@@ -98,10 +108,13 @@ def prompt_for_settings() -> Settings:
                 continue
             raise ex
 
-    assistants: List[Assistant] = []
+    assistants: Dict[str, Assistant] = {}
     for da in DEFAULT_ASSISTANTS:
-        assistant = ai.create_assistant(**asdict(da))
-        assistants.append(assistant) # type: ignore[reportUnboundVariable]
+        da = copy.copy(da)
+        assistant = ai.create_assistant(**da.to_create_params())
+        da.id = assistant.id
+        assistants[da.name] = da
+        # assistants.append(assistant) # type: ignore[reportUnboundVariable]
 
     # TODO(justin): maybe add ability to select data mode. possibly a cli option to re-configure settings too.
     # it's not too important, for now it'll default to binary and can be changed manually.
@@ -110,7 +123,7 @@ def prompt_for_settings() -> Settings:
         api_key = api_key, 
         model = model, 
         assistant_id = "", # NOTE(justin): deprecated in version 0.3.0
-        assistants = {a.name: a.id for a in assistants}, # type: ignore[reportUnboundVariable]
+        assistants = assistants,
         data_mode = Settings.DEFAULT_DATA_MODE,
         compression = Settings.DEFAULT_COMPRESSION
     )

--- a/summawise/settings.py
+++ b/summawise/settings.py
@@ -1,11 +1,12 @@
-import json, os, copy
+import json, os, copy, warnings
 from dataclasses import dataclass, fields, field
-from typing import Set, Optional, Dict, List, Any, ClassVar
+from typing import Set, Optional, Dict, List, Any, ClassVar, Tuple
 from openai import AuthenticationError, BadRequestError
+from pathlib import Path
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
 from . import utils, ai
-from .utils import Singleton
+from .utils import Singleton, classproperty
 from .data import DataMode
 from .files import utils as FileUtils
 from .assistants import DEFAULT_ASSISTANTS, DEFAULT_MODEL, Assistant, AssistantList
@@ -23,15 +24,31 @@ class Settings(metaclass = Singleton):
     DEFAULT_COMPRESSION: ClassVar[bool] = True
     DEFAULT_DATA_MODE: ClassVar[DataMode] = DataMode.BIN
     DEPRECATED_FIELDS: ClassVar[Set[str]] = {"assistant_id"}
-    FORCE_SAVE: ClassVar[bool] = False
 
     # NOTE(justin): This class functions as a singleton. Example usage anywhere:
     # settings = Settings() # type: ignore (dismiss warnings related to required arguments)
     # print(settings.to_dict()) # contains info established in main()
 
+    @classproperty
+    def file(cls) -> Path:
+        return utils.get_summawise_dir() / "settings.json"
+
     @staticmethod
-    def from_dict(data: Dict[str, Any]) -> "Settings":
-        assistant_id = data.pop("assistant_id", None)
+    def from_dict(data: Dict[str, Any]) -> Tuple["Settings", bool]:
+        """
+        Create a Settings object from a dictionary representation.
+
+        Parameters:
+            data (Dict[str, Any]): A dictionary containing the settings data.
+
+        Returns:
+            Tuple["Settings", bool]: A tuple containing the Settings object created from the data and a boolean indicating whether the settings should be updated.
+        """
+        key_count = len(data)
+        expected_key_count = len(fields(Settings)) - len(Settings.DEPRECATED_FIELDS)
+        save = key_count != expected_key_count
+
+        assistant_id = data.pop("assistant_id", None) # NOTE(justin): deprecated in version 0.3.0
         assistants = data.pop("assistants", [])
         assistants = AssistantList.from_dict_list(assistants)
 
@@ -48,12 +65,15 @@ class Settings(metaclass = Singleton):
         if settings.assistant_id:
             ai.init(settings.api_key, verify = False)
             api_assistant = ai.get_assistant(assistant_id)
-            default_assistant = copy.copy(DEFAULT_ASSISTANTS[0])
-            default_assistant.apply_api_obj(api_assistant)
-            assistants.append(default_assistant)
-            Settings.FORCE_SAVE = True
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                assistant = Assistant()
+            assistant.apply_api_obj(api_assistant)
+            assert assistant.name and assistant.instructions
+            assistants.append(assistant)
+            save = True
 
-        return settings
+        return settings, save
 
     def to_dict(self) -> Dict[str, Any]:
         data = utils.asdict_exclude(self, Settings.DEPRECATED_FIELDS)
@@ -61,75 +81,82 @@ class Settings(metaclass = Singleton):
         data["data_mode"] = self.data_mode.value
         return data
 
-def init_settings() -> Settings:
-    settings_file = utils.get_summawise_dir() / "settings.json"
-    if settings_file.exists():
-        s_str = FileUtils.read_str(settings_file)
-        s_dict = json.loads(s_str)
-        settings = Settings.from_dict(s_dict)
-        save = len(s_dict) != len(fields(Settings))
-    else:
-        settings = prompt_for_settings()
-        save = True
-    
-    # initialize openai api
-    # TODO(justin): key verification after settings init in main
-    ai.init(settings.api_key, verify = False)
+    @staticmethod
+    def init() -> "Settings":
+        file = Settings.file
+        if file.exists():
+            s_str = FileUtils.read_str(file)
+            s_dict = json.loads(s_str)
+            settings, save = Settings.from_dict(s_dict)
+        else:
+            settings = Settings.prompt()
+            save = True
+        
+        # initialize openai api
+        # TODO(justin): key verification after settings init in main
+        ai.init(settings.api_key, verify = False)
 
-    # automatically create default assistants added in future versions
-    for da in DEFAULT_ASSISTANTS:
-        if not settings.assistants.get_by_name(da.name):
+        # automatically create default assistants added in future versions
+        for da in DEFAULT_ASSISTANTS:
+            if not settings.assistants.get_by_name(da.name):
+                assistant = copy.copy(da)
+                api_assistant = ai.create_assistant(**da.to_create_params())
+                assistant.apply_api_obj(api_assistant)
+                settings.assistants.append(assistant)
+                save = True
+        
+        if save:
+            Settings.save()
+
+        return settings
+
+    @staticmethod
+    def save() -> "Settings":
+        settings = Settings() # type: ignore
+        s_str = json.dumps(settings.to_dict(), indent = 4)
+        FileUtils.write_str(Settings.file, s_str)
+        return settings
+
+    @staticmethod
+    def prompt() -> "Settings":
+        api_key = os.getenv("OPENAI_API_KEY", "")
+        api_key = validate_api_key(api_key)
+        
+        while api_key is None:
+            api_key = prompt("Enter your OpenAI API key: ")
+            api_key = validate_api_key(api_key)
+            if not api_key:
+                print("The API key you entered is invalid. Try again.")
+
+        model_completer = WordCompleter(["gpt-4o", "gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"])
+        while True:
+            try:
+                model = prompt(f"Enter the OpenAI model to use [Default: {Settings.DEFAULT_MODEL}]: ", completer = model_completer)
+                break
+            except BadRequestError as ex:
+                if ex.code == "model_not_found":
+                    print("The model identifier you entered is invalid. Try again.")
+                    continue
+                raise ex
+
+        assistants: List[Assistant] = []
+        for da in DEFAULT_ASSISTANTS:
             assistant = copy.copy(da)
             api_assistant = ai.create_assistant(**da.to_create_params())
             assistant.apply_api_obj(api_assistant)
-            settings.assistants.append(assistant)
-            save = True
-    
-    if save or Settings.FORCE_SAVE:
-        s_str = json.dumps(settings.to_dict(), indent = 4)
-        FileUtils.write_str(settings_file, s_str)
+            assistants.append(assistant)
 
-    return settings
+        # TODO(justin): maybe add ability to select data mode. possibly a cli option to re-configure settings too.
+        # it's not too important, for now it'll default to binary and can be changed manually.
 
-def prompt_for_settings() -> Settings:
-    api_key = os.getenv("OPENAI_API_KEY", "")
-    api_key = validate_api_key(api_key)
-    
-    while api_key is None:
-        api_key = prompt("Enter your OpenAI API key: ")
-        api_key = validate_api_key(api_key)
-        if not api_key:
-            print("The API key you entered is invalid. Try again.")
-
-    model_completer = WordCompleter(["gpt-4o", "gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"])
-    while True:
-        try:
-            model = prompt(f"Enter the OpenAI model to use [Default: {Settings.DEFAULT_MODEL}]: ", completer = model_completer)
-            break
-        except BadRequestError as ex:
-            if ex.code == "model_not_found":
-                print("The model identifier you entered is invalid. Try again.")
-                continue
-            raise ex
-
-    assistants: List[Assistant] = []
-    for da in DEFAULT_ASSISTANTS:
-        assistant = copy.copy(da)
-        api_assistant = ai.create_assistant(**da.to_create_params())
-        assistant.apply_api_obj(api_assistant)
-        assistants.append(assistant)
-
-    # TODO(justin): maybe add ability to select data mode. possibly a cli option to re-configure settings too.
-    # it's not too important, for now it'll default to binary and can be changed manually.
-
-    return Settings(
-        api_key = api_key, 
-        model = model, 
-        assistant_id = "", # NOTE(justin): deprecated in version 0.3.0
-        assistants = AssistantList(assistants),
-        data_mode = Settings.DEFAULT_DATA_MODE,
-        compression = Settings.DEFAULT_COMPRESSION
-    )
+        return Settings(
+            api_key = api_key, 
+            model = model, 
+            assistant_id = "", # NOTE(justin): deprecated in version 0.3.0
+            assistants = AssistantList(assistants),
+            data_mode = Settings.DEFAULT_DATA_MODE,
+            compression = Settings.DEFAULT_COMPRESSION
+        )
 
 def validate_api_key(api_key: str) -> Optional[str]:
     try:

--- a/summawise/utils.py
+++ b/summawise/utils.py
@@ -121,7 +121,7 @@ def delete_lines(count: int = 1):
 
 converter_iso: Callable[[datetime], str] = lambda v: v.isoformat()
 converter_ts: Callable[[datetime], float] = lambda v: v.timestamp()
-converter_ts_int: Callable[[datetime], float] = lambda v: v.timestamp()
+converter_ts_int: Callable[[datetime], float] = lambda v: int(v.timestamp())
 
 def convert_datetimes(
     input_dict: Dict[str, Any], 

--- a/summawise/utils.py
+++ b/summawise/utils.py
@@ -20,15 +20,6 @@ class Singleton(type):
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
 
-class classproperty:
-    # Normal class properties were deprecated in Python 3.11
-    # This is a custom decorator to achieve effectively the same thing
-    # Source: https://stackoverflow.com/a/76301341
-    def __init__(self, func):
-        self.fget = func
-    def __get__(self, _, owner):
-        return self.fget(owner)
-
 class NumericChoiceValidator(Validator):
 
     def __init__(self, valid_choices):

--- a/summawise/utils.py
+++ b/summawise/utils.py
@@ -121,6 +121,7 @@ def delete_lines(count: int = 1):
 
 converter_iso: Callable[[datetime], str] = lambda v: v.isoformat()
 converter_ts: Callable[[datetime], float] = lambda v: v.timestamp()
+converter_ts_int: Callable[[datetime], float] = lambda v: v.timestamp()
 
 def convert_datetimes(
     input_dict: Dict[str, Any], 
@@ -130,6 +131,7 @@ def convert_datetimes(
     Converts datetime objects in the input dictionary based on the converter func.
         - converter_iso: returns datetime.isoformat() [DEFAULT]
         - converter_ts: returns datetime.timestamp()
+        - converter_ts_int: returns int(datetime.timestamp())
     Recursively applies the conversion to nested dictionaries.
 
     Args:

--- a/summawise/utils.py
+++ b/summawise/utils.py
@@ -20,6 +20,15 @@ class Singleton(type):
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
 
+class classproperty:
+    # Normal class properties were deprecated in Python 3.11
+    # This is a custom decorator to achieve effectively the same thing
+    # Source: https://stackoverflow.com/a/76301341
+    def __init__(self, func):
+        self.fget = func
+    def __get__(self, _, owner):
+        return self.fget(owner)
+
 class NumericChoiceValidator(Validator):
 
     def __init__(self, valid_choices):

--- a/summawise/utils.py
+++ b/summawise/utils.py
@@ -1,7 +1,8 @@
 import tempfile, sys
+from datetime import datetime
 from dataclasses import is_dataclass, fields
 from importlib import metadata
-from typing import Any, Union, Tuple, Set, Dict
+from typing import Any, Callable, Union, Tuple, Set, Dict
 from pathlib import Path
 from packaging.version import Version
 from .errors import ValueTypeError
@@ -10,6 +11,7 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.validation import Validator, ValidationError
 
 package_name = lambda: __name__.split('.')[0]
+utc_now = lambda: datetime.utcnow()
 
 class Singleton(type):
     _instances = {}
@@ -116,3 +118,32 @@ def delete_lines(count: int = 1):
         sys.stdout.write(CURSOR_UP_ONE)
         sys.stdout.write(ERASE_LINE)
     sys.stdout.flush()
+
+converter_iso: Callable[[datetime], str] = lambda v: v.isoformat()
+converter_ts: Callable[[datetime], float] = lambda v: v.timestamp()
+
+def convert_datetimes(
+    input_dict: Dict[str, Any], 
+    converter: Callable[[datetime], Any] = converter_iso
+) -> Dict[str, Any]:
+    """
+    Converts datetime objects in the input dictionary based on the converter func.
+        - converter_iso: returns datetime.isoformat() [DEFAULT]
+        - converter_ts: returns datetime.timestamp()
+    Recursively applies the conversion to nested dictionaries.
+
+    Args:
+        input_dict (Dict[str, Any]): A dictionary where keys are strings and values can be of any type.
+
+    Returns:
+        Dict[str, Any]: A dict with the same keys as the input dictionary, but with datetime objects converted to ISO formatted strings.
+    """
+    output = {}
+    for key, value in input_dict.items():
+        if isinstance(value, datetime):
+            output[key] = converter(value)
+        elif isinstance(value, dict):
+            output[key] = convert_datetimes(value, converter)
+        else:
+            output[key] = value
+    return output

--- a/summawise/utils.py
+++ b/summawise/utils.py
@@ -2,7 +2,7 @@ import tempfile, sys
 from datetime import datetime
 from dataclasses import is_dataclass, fields
 from importlib import metadata
-from typing import Any, Callable, Union, Tuple, Set, Dict
+from typing import Any, Optional, Callable, Union, Tuple, Set, Dict
 from pathlib import Path
 from packaging.version import Version
 from .errors import ValueTypeError
@@ -149,3 +149,9 @@ def convert_datetimes(
         else:
             output[key] = value
     return output
+
+def try_parse_int(value: str, default: Optional[int] = None) -> Optional[int]:
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default


### PR DESCRIPTION
The following commands are implemented by the code in this PR:
```
└─Δ summawise assistant
Usage: summawise assistant [OPTIONS] COMMAND [ARGS]...

  Commands related to managing assistants.

Options:
  --help  Show this message and exit.

Commands:
  create  Create a new assistant.
  delete  Delete an assistant.
  list    List your available assistants.
```

Additional parameters related to assistant creation:
```
└─Δ summawise assistant create --help
Usage: summawise assistant create [OPTIONS]

  Create a new assistant.

Options:
  -n, --name TEXT            The name of the assistant.
  -i, --instructions TEXT    Instructions for the assistant.
  -m, --model TEXT           The model to use.
  -d, --description TEXT     Description of the assistant.
  -fs, --file_search         Enable file search capability.
  -ic, --interpret_code      Enable code interpretation capability.
  -rwj, --respond_with_json  Responses should be in valid JSON format.
  --temperature FLOAT        Temperature setting for the model.
  --top_p FLOAT              Top-p setting for the model.
  --help                     Show this message and exit.
```
Still some tidying up to do regarding how these assistants are utilized by the `scan` command, or in other ways.