### PR TITLE
Add "thread" commands/ability to save & restore threads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "summawise"
-version = "0.4.1"
+version = "0.5.0"
 description = "Summarize information from vectorized files using OpenAI's powerful models, and explore data further with an interactive prompt for deep dives into content."
 authors = [{ name = "Justin Garofolo", email = "justin@garofolo.net" }]
 license = { text = "GPLv3" }

--- a/summawise/ai.py
+++ b/summawise/ai.py
@@ -247,6 +247,9 @@ def create_assistant(
 def get_assistant(id: str) -> Assistant:
     return Client.beta.assistants.retrieve(id)
 
+def get_thread(id: str) -> Thread:
+    return Client.beta.threads.retrieve(id)
+
 def create_thread(resources: Resources, file_search: bool = False, code_interpreter: bool = False) -> Thread:
     # https://platform.openai.com/docs/api-reference/threads/createThread#threads-createthread-tool_resources
 

--- a/summawise/api_objects/__init__.py
+++ b/summawise/api_objects/__init__.py
@@ -1,0 +1,3 @@
+from .generic import *
+from .assistants import *
+from .threads import *

--- a/summawise/api_objects/assistants.py
+++ b/summawise/api_objects/assistants.py
@@ -2,9 +2,9 @@ import warnings
 from typing import Dict, List, Optional, TypeVar, NamedTuple, Iterable
 from datetime import datetime, timezone
 from dataclasses import dataclass, field
-from . import utils
-from .utils import ApiObjList, BaseApiObj
-from .data import HashAlg
+from .. import utils
+from .generic import ApiObjList, BaseApiObj
+from ..data import HashAlg
 from openai.types.beta import Assistant as APIAssistant
 
 T = TypeVar('T')

--- a/summawise/api_objects/generic.py
+++ b/summawise/api_objects/generic.py
@@ -1,7 +1,14 @@
+from dataclasses import dataclass, asdict
 from typing import  List, Set, Tuple, Iterable, Optional, Callable, TypeVar, ClassVar, Generic, Protocol
 from datetime import datetime
 from .. import utils
 from ..errors import MultipleObjectsFoundError, MissingSortKeyError
+
+@dataclass
+class BaseApiObj:
+    def to_dict(self) -> dict:
+        obj = asdict(self)
+        return utils.convert_datetimes(obj, converter = utils.converter_ts_int)
 
 class ApiObjItem(Protocol):
     id: str

--- a/summawise/api_objects/threads.py
+++ b/summawise/api_objects/threads.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, asdict, field
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Iterable
 from openai.types.beta import Thread as APIThread
@@ -19,9 +19,9 @@ class Thread(BaseApiObj):
 
 class ThreadList(ApiObjList[Thread]):
 
-    def __init__(self, assistants: Iterable[Thread] = [], **kwargs):
-        super().__init__(assistants, cls = Thread, **kwargs)
+    def __init__(self, threads: Iterable[Thread] = [], **kwargs):
+        super().__init__(threads, cls = Thread, **kwargs)
 
     @staticmethod
-    def from_dict_list(assistants: Iterable[Thread], **kwargs) -> "ThreadList": # type: ignore
-        return ApiObjList.from_dict_list(assistants, cls = Assistant, **kwargs) # type: ignore
+    def from_dict_list(threads: Iterable[Thread], **kwargs) -> "ThreadList": # type: ignore
+        return ApiObjList.from_dict_list(threads, cls = Thread, **kwargs) # type: ignore

--- a/summawise/api_objects/threads.py
+++ b/summawise/api_objects/threads.py
@@ -1,14 +1,15 @@
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Iterable
+from typing import Iterable, Tuple
 from openai.types.beta import Thread as APIThread
 from .. import utils, ai
 from .generic import ApiObjList, BaseApiObj
 
 @dataclass
 class Thread(BaseApiObj):
-    id: str = ""
-    name: str = ""
+    id: str
+    name: str
+    assistant: Tuple[str, str] # name, id
     created_at: datetime = field(default_factory = utils.utc_now)
 
     def get_api_obj(self) -> APIThread:

--- a/summawise/api_objects/threads.py
+++ b/summawise/api_objects/threads.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass, asdict, field
 from datetime import datetime
 from typing import Iterable
 from openai.types.beta import Thread as APIThread
-from . import utils, ai
-from .utils import ApiObjList, BaseApiObj
+from .. import utils, ai
+from .generic import ApiObjList, BaseApiObj
 
 @dataclass
 class Thread(BaseApiObj):

--- a/summawise/commands/__init__.py
+++ b/summawise/commands/__init__.py
@@ -1,2 +1,3 @@
 from .scan import scan
 from .assistants import assistant
+from .threads import thread

--- a/summawise/commands/assistants.py
+++ b/summawise/commands/assistants.py
@@ -2,7 +2,7 @@ import click
 from click import types as ctypes
 from typing import Optional
 from .. import ai, utils
-from ..assistants import Assistant
+from ..api_objects import Assistant
 from ..settings import Settings
 from ..data import HashAlg
 

--- a/summawise/commands/assistants.py
+++ b/summawise/commands/assistants.py
@@ -1,7 +1,7 @@
 import click
 from click import types as ctypes
 from typing import Optional
-from .. import ai, utils
+from .. import ai
 from ..api_objects import Assistant
 from ..settings import Settings
 from ..data import HashAlg

--- a/summawise/commands/scan.py
+++ b/summawise/commands/scan.py
@@ -163,7 +163,7 @@ def scan(ctx: click.Context, user_input: Tuple[str, ...], thread_name: str):
     print("\nYou can now ask questions about the content. Type 'exit' to quit.")
     while True:
         input_str = prompt("\nyou > ")
-        conditional_exit(input_str)
+        utils.conditional_exit(input_str)
         try:
             ai.get_thread_response(thread.id, assistant.id, input_str, auto_print = True)
         except Exception as ex:
@@ -171,7 +171,7 @@ def scan(ctx: click.Context, user_input: Tuple[str, ...], thread_name: str):
 
 def process_input(user_input: str) -> ai.Resources:
     """Takes user input, attempts to return OpenAI VectorStore ID after processing data."""
-    conditional_exit(user_input)
+    utils.conditional_exit(user_input)
 
     path = Path(user_input)
     if path.exists():
@@ -184,10 +184,3 @@ def process_input(user_input: str) -> ai.Resources:
         return process_url(user_input)
 
     raise NotSupportedError()
-
-def conditional_exit(user_input: str) -> None:
-    """Conditionally exit the program based on the users input."""
-    if user_input.lower() in ["exit", "quit", ":q"]:
-        if user_input == ":q": 
-            print("They should call you Vim Diesel.") # NOTE(justin): this is here to stay
-        sys.exit()

--- a/summawise/commands/scan.py
+++ b/summawise/commands/scan.py
@@ -4,7 +4,7 @@ from typing import Tuple, Dict, Optional
 from prompt_toolkit import prompt
 from pathlib import Path
 from .. import ai, utils
-from ..assistants import Assistant, CONVERSATION_INITS, ConversationInit
+from ..api_objects import Assistant, CONVERSATION_INITS, ConversationInit
 from ..settings import Settings
 from ..web import process_url
 from ..files.processing import process_file, process_dir

--- a/summawise/commands/scan.py
+++ b/summawise/commands/scan.py
@@ -137,7 +137,8 @@ def scan(ctx: click.Context, user_input: Tuple[str, ...], thread_name: str):
     # create internal representation of the thread (simplified)
     thread = Thread(
         id = api_thread.id, 
-        name = thread_name, 
+        name = thread_name,
+        assistant = (assistant.name, assistant.id),
         created_at = datetime.fromtimestamp(api_thread.created_at, timezone.utc) 
     )
 

--- a/summawise/commands/scan.py
+++ b/summawise/commands/scan.py
@@ -14,8 +14,9 @@ from ..data import DataUnit
 
 @click.command()
 @click.argument("user_input", nargs = -1)
+@click.option("-tn", "--thread_name", help = "The name of the thread. [Optional: can't be restored if not specified.]")
 @click.pass_context
-def scan(ctx: click.Context, user_input: Tuple[str, ...]):
+def scan(ctx: click.Context, user_input: Tuple[str, ...], thread_name: str):
     """Scan and process the given input (URL or file path), and offer an interactive prompt to inquire about the vectorized data."""
     settings = Settings() # type: ignore
     FileCache.init()

--- a/summawise/commands/threads.py
+++ b/summawise/commands/threads.py
@@ -1,0 +1,34 @@
+import click
+from ..settings import Settings
+
+@click.group()
+def thread():
+    """Commands related to managing threads."""
+    pass
+
+@thread.command()
+def list():
+    """List your available threads."""
+    settings = Settings() # type: ignore
+    for idx, thread in enumerate(settings.threads, start = 1):
+        print(f"{idx}) {thread.name}")
+
+
+@thread.command()
+@click.argument("thread_id", type = str)
+def delete(thread_id: str):
+    """
+    Delete a thread.\n
+    Provided ID can be the thread name, id, or number from 'list'.
+    """
+    settings = Settings() # type: ignore
+
+    thread, idx = settings.threads.get(thread_id)
+    if not thread:
+        print("Failed to identify thread to delete.")
+        return
+
+    del settings.threads[idx]
+    settings.save()
+    print(f"Deleted thread successfully: {thread.name}")
+

--- a/summawise/commands/threads.py
+++ b/summawise/commands/threads.py
@@ -1,4 +1,6 @@
 import click
+from prompt_toolkit import prompt
+from .. import ai, utils
 from ..settings import Settings
 
 @click.group()
@@ -32,3 +34,37 @@ def delete(thread_id: str):
     settings.save()
     print(f"Deleted thread successfully: {thread.name}")
 
+@thread.command()
+@click.argument("thread_id", type = str)
+@click.pass_context
+def restore(ctx: click.Context, thread_id: str):
+    """Restore a saved thread from its latest state."""
+    settings = Settings() # type: ignore
+    debug = ctx.obj.get("DEBUG", False)
+
+    thread, _ = settings.threads.get(thread_id)
+    if not thread:
+        print("No thread found matching provided identifier.")
+        return
+
+    assistant_name, assistant_id = thread.assistant
+    assistant, _ = settings.assistants.get(assistant_name)
+    if assistant is not None:
+        assistant_id = assistant.id
+
+    # get a summary of where the conversation (aka "thread") left off
+    try:
+        ai.get_thread_response(thread.id, assistant_id, "Please summarize our conversation thus far.", auto_print = True)
+    except Exception as ex:
+        print(f"Error initializing conversation: {utils.ex_to_str(ex, include_traceback = debug)}")
+        return
+    
+    # resume interactive prompt (from scan command) with restored thread
+    print("\nYou can now continue to ask questions about the content. Type 'exit' to quit.")
+    while True:
+        input_str = prompt("\nyou > ")
+        utils.conditional_exit(input_str)
+        try:
+            ai.get_thread_response(thread.id, assistant_id, input_str, auto_print = True)
+        except Exception as ex:
+            print(f"\nError occurred during conversation: {utils.ex_to_str(ex, include_traceback = debug)}")

--- a/summawise/main.py
+++ b/summawise/main.py
@@ -1,6 +1,6 @@
 import click, sys
 from .utils import get_version
-from .commands import scan, assistant
+from .commands import assistant, scan, thread
 from .settings import Settings
 
 VERSION = get_version()
@@ -18,6 +18,7 @@ def cli(ctx: click.Context, debug: bool):
 def register_commands():
     cli.add_command(scan)
     cli.add_command(assistant)
+    cli.add_command(thread)
 
 def main():
     Settings.init()

--- a/summawise/settings.py
+++ b/summawise/settings.py
@@ -10,7 +10,7 @@ from . import utils, ai
 from .utils import Singleton, ChoiceValidator
 from .data import DataMode
 from .files import utils as FileUtils
-from .assistants import DEFAULT_ASSISTANTS, DEFAULT_MODEL, Assistant, AssistantList
+from .api_objects import DEFAULT_ASSISTANTS, DEFAULT_MODEL, Assistant, AssistantList
     
 @dataclass
 class Settings(metaclass = Singleton):

--- a/summawise/settings.py
+++ b/summawise/settings.py
@@ -10,17 +10,18 @@ from . import utils, ai
 from .utils import Singleton, ChoiceValidator
 from .data import DataMode
 from .files import utils as FileUtils
-from .api_objects import DEFAULT_ASSISTANTS, DEFAULT_MODEL, Assistant, AssistantList
+from .api_objects import *
     
 @dataclass
 class Settings(metaclass = Singleton):
     api_key: str
     assistant_id: str = field(repr = False) # NOTE(justin): deprecated in version 0.3.0
-    assistants: AssistantList
     model: str
     compression: bool
     data_mode: DataMode
     code_style: str
+    assistants: AssistantList
+    threads: ThreadList
 
     DEPRECATED_FIELDS: ClassVar[Set[str]] = {"assistant_id"}
     DEFAULT_MODEL: ClassVar[str] = DEFAULT_MODEL
@@ -51,9 +52,13 @@ class Settings(metaclass = Singleton):
         assistants = data.pop("assistants", [])
         assistants = AssistantList.from_dict_list(assistants)
 
+        threads = data.pop("threads", [])
+        threads = ThreadList.from_dict_list(threads)
+
         settings = Settings(
             assistant_id = assistant_id,
             assistants = assistants,
+            threads = threads,
             model = data.pop("model", Settings.DEFAULT_MODEL),
             compression = data.pop("compression", Settings.DEFAULT_COMPRESSION),
             code_style = data.pop("code_style", Settings.DEFAULT_CODE_STYLE),
@@ -78,6 +83,7 @@ class Settings(metaclass = Singleton):
     def to_dict(self) -> Dict[str, Any]:
         data = utils.asdict_exclude(self, Settings.DEPRECATED_FIELDS)
         data["assistants"] = self.assistants.to_dict_list()
+        data["threads"] = self.threads.to_dict_list()
         data["data_mode"] = self.data_mode.value
         return data
 
@@ -172,6 +178,7 @@ class Settings(metaclass = Singleton):
             model = model, 
             assistant_id = "", # NOTE(justin): deprecated in version 0.3.0
             assistants = AssistantList(assistants),
+            threads = ThreadList(),
             compression = Settings.DEFAULT_COMPRESSION,
             code_style = style,
             data_mode = Settings.DEFAULT_DATA_MODE,

--- a/summawise/threads.py
+++ b/summawise/threads.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, asdict, field
+from datetime import datetime
+from typing import Iterable
+from openai.types.beta import Thread as APIThread
+from . import utils, ai
+from .utils import ApiObjList, BaseApiObj
+
+@dataclass
+class Thread(BaseApiObj):
+    id: str = ""
+    name: str = ""
+    created_at: datetime = field(default_factory = utils.utc_now)
+
+    def get_api_obj(self) -> APIThread:
+        if not self.id:
+            raise ValueError("Thread ID must be specified to retrieve API object.")
+        api_thread = ai.get_thread(self.id)
+        return api_thread
+
+class ThreadList(ApiObjList[Thread]):
+
+    def __init__(self, assistants: Iterable[Thread] = [], **kwargs):
+        super().__init__(assistants, cls = Thread, **kwargs)
+
+    @staticmethod
+    def from_dict_list(assistants: Iterable[Thread], **kwargs) -> "ThreadList": # type: ignore
+        return ApiObjList.from_dict_list(assistants, cls = Assistant, **kwargs) # type: ignore

--- a/summawise/utils/__init__.py
+++ b/summawise/utils/__init__.py
@@ -1,4 +1,3 @@
 from .misc import *
 from .validators import *
 from .terminal import *
-from .aot_list import ApiObjList

--- a/summawise/utils/misc.py
+++ b/summawise/utils/misc.py
@@ -13,12 +13,6 @@ from .. import utils
 package_name = lambda: __name__.split('.')[0]
 utc_now = lambda: datetime.utcnow()
 
-@dataclass
-class BaseApiObj:
-    def to_dict(self) -> dict:
-        obj = asdict(self)
-        return utils.convert_datetimes(obj, converter = utils.converter_ts_int)
-
 class Singleton(type):
     _instances = {}
     def __call__(cls, *args, **kwargs):

--- a/summawise/utils/misc.py
+++ b/summawise/utils/misc.py
@@ -190,3 +190,10 @@ def calculate_hash(
     """
     assert_type(_input, (bytes, str, Path))
     return algorithm.calculate(_input, intdigest)
+
+def conditional_exit(user_input: str) -> None:
+    """Conditionally exit the program based on the users input."""
+    if user_input.lower() in ["exit", "quit", ":q"]:
+        if user_input == ":q": 
+            print("They should call you Vim Diesel.") # NOTE(justin): this is here to stay
+        sys.exit()

--- a/summawise/utils/validators.py
+++ b/summawise/utils/validators.py
@@ -23,16 +23,31 @@ class NumericChoiceValidator(Validator):
 
 class ChoiceValidator(Validator):
 
-    def __init__(self, valid_choices: List[str], allow_empty: bool = False):
-        self.valid_choices = valid_choices
+    def __init__(
+        self, 
+        choices: List[str],
+        is_blacklist: bool = False,
+        allow_empty: bool = False,
+        case_sensitive: bool = True,
+        invalid_message: str = "The choice you have input is invalid."
+    ):
+        self.choices = choices
+        self.is_blacklist = is_blacklist
+        self.case_sensitive = case_sensitive
+        self.invalid_message = invalid_message
+
         if allow_empty:
-            self.valid_choices.append("")
+            self.choices.remove("") if is_blacklist else self.choices.append("")
+
+        if not case_sensitive:
+            self.choices = [c.lower() for c in self.choices]
 
     def validate(self, document: Document):
-        choice = document.text # input as a string
-        if choice not in self.valid_choices:
+        choice = document.text if self.case_sensitive else document.text.lower() # input as a string
+        valid = choice not in self.choices if self.is_blacklist else choice in self.choices
+        if not valid:
             raise ValidationError(
-                message = "The choice you have input is invalid.",
+                message = self.invalid_message,
                 cursor_position = len(document.text)
             )
 


### PR DESCRIPTION
Threads can conceptually be thought of as conversations.
This feature allows you to save a thread when initially creating the interactive prompt via the `scan` command by providing a `--thread_name` (or `-tn`) option.
You can then restore that threat (or conversation) after your done interacting with the data thus far.

This would be the output of `summawise thread --help`, to introduce the new commands:
```
Usage: summawise thread [OPTIONS] COMMAND [ARGS]...

  Commands related to managing threads.

Options:
  --help  Show this message and exit.

Commands:
  delete   Delete a thread.
  list     List your available threads.
  restore  Restore a saved thread from its latest state.
```